### PR TITLE
fix VTK type error

### DIFF
--- a/bg_atlasgen/mesh_utils.py
+++ b/bg_atlasgen/mesh_utils.py
@@ -123,10 +123,10 @@ def extract_mesh_from_mask(
 
     # Apply morphological transformations
     if closing_n_iters is not None:
-        volume = scipy.ndimage.morphology.binary_fill_holes(volume)
+        volume = scipy.ndimage.morphology.binary_fill_holes(volume).astype(int)
         volume = scipy.ndimage.morphology.binary_closing(
             volume, iterations=closing_n_iters
-        )
+        ).astype(int)
 
     if not use_marching_cubes:
         # Use faster algorithm


### PR DESCRIPTION
VTK type error as discussed in #31

caused by 
```
    if closing_n_iters is not None:
        volume = scipy.ndimage.morphology.binary_fill_holes(volume).astype(int)
        volume = scipy.ndimage.morphology.binary_closing(
            volume, iterations=closing_n_iters
        ).astype(int)
```
in mesh_utils returning bool and VTK typing not liking it. So convert to int.